### PR TITLE
ascal: fix stale right-edge pixel on the last active column

### DIFF
--- a/sys/ascal.vhd
+++ b/sys/ascal.vhd
@@ -1030,6 +1030,7 @@ ARCHITECTURE rtl OF ascal IS
 	SIGNAL o_poly_phase_b,o_poly_phase_b2,o_poly_phase_b3 : poly_phase_t;
 	SIGNAL o_v_poly_phase, o_v_poly_phase2, o_h_poly_phase, o_poly_phase, o_poly_phase1 : poly_phase_interp_t;
 	SIGNAL o_v_poly_pix, o_h_poly_pix, o_h_lum_pix, o_v_lum_pix : type_pix;
+	SIGNAL o_rlast : type_pix;
 	SIGNAL o_poly_lum, o_poly_lum1 : unsigned(7 DOWNTO 0);
 	SIGNAL o_poly_lerp_ta, o_poly_lerp_tb : signed(9 DOWNTO 0);
 	SIGNAL o_h_poly_t,o_h_poly_t2,o_v_poly_t   : type_poly_t;
@@ -2837,6 +2838,7 @@ BEGIN
 		VARIABLE r1_v, r2_v : natural RANGE 0 TO OHRESH-1;
 		VARIABLE fracnn_v : std_logic;
 		VARIABLE o_l0_v, o_l1_v, o_l2_v, o_l3_v : type_pix;
+		VARIABLE opix_v : type_pix;
 	BEGIN
 		IF rising_edge(o_clk) THEN
 			IF o_ce='1' THEN
@@ -2972,45 +2974,45 @@ BEGIN
 				o_vs<=o_vsv(11);
 				o_de<=o_dev(11);
 				o_vbl<=o_end(11);
-				o_r<=x"00";
-				o_g<=x"00";
-				o_b<=x"00";
 				o_brd<= not o_pev(11);
 
+				opix_v := (r=>x"00", g=>x"00", b=>x"00");
 				CASE o_vmode(2 DOWNTO 0) IS
 					WHEN "000" => -- Nearest
 						IF MASK(MASK_NEAREST)='1' THEN
-							o_r<=o_v_poly_pix.r;
-							o_g<=o_v_poly_pix.g;
-							o_b<=o_v_poly_pix.b;
+							opix_v := o_v_poly_pix;
 						END IF;
 					WHEN "001" | "010" => -- Bilinear | Sharp Bilinear
 						IF MASK(MASK_BILINEAR)='1' OR
 							 MASK(MASK_SHARP_BILINEAR)='1' THEN
-							o_r<=o_v_bil_pix.r;
-							o_g<=o_v_bil_pix.g;
-							o_b<=o_v_bil_pix.b;
+							opix_v := o_v_bil_pix;
 						END IF;
 					WHEN "011" => -- BiCubic
 						IF MASK(MASK_BICUBIC)='1' THEN
-							o_r<=o_v_bic_pix.r;
-							o_g<=o_v_bic_pix.g;
-							o_b<=o_v_bic_pix.b;
+							opix_v := o_v_bic_pix;
 						END IF;
 
 					WHEN OTHERS => -- Polyphase
 						IF MASK(MASK_POLY)='1' THEN
-							o_r<=o_v_poly_pix.r;
-							o_g<=o_v_poly_pix.g;
-							o_b<=o_v_poly_pix.b;
+							opix_v := o_v_poly_pix;
 						END IF;
 				END CASE;
 
 				IF o_pev(11)='0' THEN
-					o_r<=o_border(23 DOWNTO 16); -- Copy border colour
-					o_g<=o_border(15 DOWNTO 8);
-					o_b<=o_border(7  DOWNTO 0);
+					opix_v := (r=>o_border(23 DOWNTO 16),
+								  g=>o_border(15 DOWNTO 8),
+								  b=>o_border(7  DOWNTO 0)); -- Copy border colour
 				END IF;
+
+				-- The line buffer fill can lag the read by one pixel at the last
+				-- active column when horizontal blanking is tight, giving a stale
+				-- right-edge pixel. Repeat the previous (valid) pixel there.
+				IF o_pev(11)='1' AND o_pev(10)='0' THEN
+					o_r<=o_rlast.r; o_g<=o_rlast.g; o_b<=o_rlast.b;
+				ELSE
+					o_r<=opix_v.r; o_g<=opix_v.g; o_b<=opix_v.b;
+				END IF;
+				o_rlast<=opix_v;
 
 				----------------------------------------------------
 			END IF;


### PR DESCRIPTION
At the last active column, the output line-buffer read will return data from the center of the display when horizontal blanking is tight. This produces a single corrupted column at the right edge on a full-width 1:1 1080p/60 framebuffer. This PR repeats the previous (valid) pixel at the last active column instead of emitting a random one.

